### PR TITLE
Monadic Party 2019 & ZuriHac 2019

### DIFF
--- a/ComputationalTrinitarianism.MD
+++ b/ComputationalTrinitarianism.MD
@@ -39,6 +39,7 @@
 * [Fancy Algebra - Part I: Adjoint Functors](http://www.math.miami.edu/~armstrong/FA/FA_part1.pdf)
 * Applied Category Theory Workshop in Leiden [(video playlist)](https://www.youtube.com/watch?v=0HMko_4cL30&list=PLE2y3n8EQ6VywrcixgTKyGHFI4A68FYSk)
 * Compositional game theory reading list - Jules Hedges [(blog post)](https://julesh.com/2017/11/09/compositional-game-theory-reading-list/)
+* UCR Applied Category Theory Seminar [(video playlist)](https://www.youtube.com/channel/UCUQlS-R4O094jP0sGHDnrjA/videos)
 
 ## Category Theory Journals
 

--- a/README.MD
+++ b/README.MD
@@ -493,7 +493,7 @@ trait Selective[F[_]] extends Applicative[F] {
 * Implementations: [Haskell](http://hackage.haskell.org/package/selective/docs/Control-Selective.html) [cb372/cats-selective](https://github.com/cb372/cats-selective/blob/master/core/src/main/scala/cats/Selective.scala)
 
 * Resources:
-  * (Haskell) Selective applicative functors - Andrey Mokhov [(blog post)](https://blogs.ncl.ac.uk/andreymokhov/selective/)
+  * (Haskell) Selective applicative functors - Andrey Mokhov [(blog post)](https://blogs.ncl.ac.uk/andreymokhov/selective/), [(video)](https://www.youtube.com/watch?v=7vruj4gj38Q)
   * (Haskell) Selective Applicative Functors Declare Your Effects Statically, Select Which to Execute Dynamically - Andrey Mokhov, Georgy Lukyanov, Simon Marlow, Jeremie Dimino [(paper)](https://www.staff.ncl.ac.uk/andrey.mokhov/selective-functors.pdf)
   * (OCaml) [snowleopard/selective-ocaml](https://github.com/snowleopard/selective-ocaml)
   * (Coq) [tuura/selective-theory-coq](https://github.com/tuura/selective-theory-coq)

--- a/README.MD
+++ b/README.MD
@@ -1848,6 +1848,7 @@ def codensityMonad[F[_], A](ran: Ran[F, F, A]): Codensity[F, A] =
   * What is a layman's explanation of "Kan extensions"? [(quora)](https://www.quora.com/What-is-a-laymans-explanation-of-Kan-extensions)
   * (Theory) [Lecture 49 - Chapter 3: Kan Extensions - John Baez](https://forum.azimuthproject.org/discussion/2266/lecture-49-chapter-3-kan-extensions/p1)
   * (Theory) [Kan Extensions for Program Optimisation Or: Art and Dan Explain an Old Trick - Ralf Hinze](https://www.cs.ox.ac.uk/ralf.hinze/publications/MPC12.pdf) (adjunctions, kan extensions, string diagrams)
+  * (Haskell) Combinatorial Species and Labelled Structures (PhD thesis) - Brent A. Yorgey [(pdf)](http://ozark.hendrix.edu/~yorgey/pub/thesis.pdf), [(repo)](https://github.com/byorgey/thesis)
   * (Hasekll) (Co-)Iteration for Higher-Order Nested Datatypes - Andreas Abel, Ralph Matthes [(paper)](http://www.cse.chalmers.se/~abela/publications.html#types02)
   * (Theory) Kan Extensions as the Most Universal of the Universal Constructions - Marina Lehner [(thesis)](http://www.math.harvard.edu/theses/senior/lehner/lehner.pdf)
 


### PR DESCRIPTION
* Edward Kmett pointed out that Kan extensions are used in Ph.D. thesis by Brent Yorgey about combinatorial species. 
* found some videos about Applied Category Theory
* add ZuriHac 2019 video about Selective Applicative Functors