### PR TITLE
Fix Disintegrate law

### DIFF
--- a/src/main/scala/disintegrate/Disintegrate.scala
+++ b/src/main/scala/disintegrate/Disintegrate.scala
@@ -20,14 +20,9 @@ trait Disintegrate[M[_]] {
   def disintegrate2[A,B](mab: M[(A,B)]): A => M[B]
 
   // https://twitter.com/Iceland_jack/status/1195787833203658752
-  def law[A,B](pairs: M[(A,B)])(implicit FM: Monad[M]): Boolean = {
-    val lhs: (M[A], A => M[B]) = disintegrate(pairs)
-    val (as,bs) = lhs
-    val rhs = for {
-      a <- as
-      b <- bs(a)
-    } yield (a,b)
-    lhs == rhs
+  def law[A, B](pairs: M[(A, B)])(implicit FM: Monad[M]): Boolean = {
+    val (a, amb): (M[A], A => M[B]) = disintegrate(pairs)
+    pairs == a.mproduct(amb)
   }
 }
 


### PR DESCRIPTION
Because current law implementation is incorrect since you know... scala & universal equality :) 
`lhs :: (m a, a -> m b)`
`rhs :: m (a, b)`

i think implementation via `mproduct` is echoing nicely with the theorem itself since disintegration is supposed to be opposite to product iiuc